### PR TITLE
Clear localStorage if HBL patch not run

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,9 @@
+if (!localStorage.getItem("hblpatch")) {
+  localStorage.clear();
+  localStorage.setItem("hblpatch", "run_OK");
+  window.location.reload();
+}
+
 // TODO: Remove 'board' from each message
 document.addEventListener('DOMContentLoaded', () => {
 	// Ensure that a session ID has been set


### PR DESCRIPTION
There are issues when using the precedent HBL patch as the messages of removed boards are still stored in localStorage. This commit clears localStorage as needed to fix this.